### PR TITLE
Add more workspace types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ This should also work from the root directory:
 cross run --manifest-path ./workspace/Cargo.toml -p binary
 ```
 
+## Specification
+
+This aims to replicate most of the features present in
+the reference [documentation](https://doc.rust-lang.org/cargo/reference/workspaces.html).
+
+AKA, we support:
+- globs
+- excludes
+
+The glob syntax is described in detail [here](https://docs.rs/glob/0.3.0/glob/struct.Pattern.html).  
+
+In short:
+- `?`: any single character.
+- `*`: 0 or more characters.
+- `**`: current directory and recursive subdirectories.
+  - `**b` and `a**` are both invalid: it must be just `**`
+- `[...]`: matches character in the set, such as `[0-9]`
+- `[!...]`: matches character not in the set, such as `[!0-9]`
+
+These syntaxes don't apply on top of each other, like more sophisticated
+regular expressions: they are simply globs. For example, `[0-9]?` matches
+`1f`, but not `1`.
+
+Adding in a non-glob member, such as `"."` for the root overrides all
+exclude patterns. For example, having a workspace like the following will
+ignore the exclude filter.
+
+```toml
+[workspace]
+members = ["folder", "folder/*"]
+exclude = ["folder/lib1"]
+```
+
 ## License
 
 Licensed under either of

--- a/workspace/Cargo.toml
+++ b/workspace/Cargo.toml
@@ -8,7 +8,51 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 external_lib = { path = "../external/external_lib" }
 member = { path = "member" }
+folder_lib1 = { optional = true, path = "folder/lib1" }
+folder_lib2 = { optional = true, path = "folder/lib2" }
+question_lib1 = { optional = true, path = "question/lib1" }
+recursive_include1 = { optional = true, path = "recursive/include1" }
+recursive_include2 = { optional = true, path = "recursive/include1/include2" }
+set_lib1 = { optional = true, path = "set/lib1" }
+set_libf = { optional = true, path = "set/libf" }
+wildcard_include = { optional = true, path = "wildcard/include" }
 
 [workspace]
 # workspace members can not be hierarchically below the workspace root
-members = [".", "member", "binary"]
+members = [
+    "member",
+    "binary",
+    "folder",
+    "folder/*",
+    "question/lib?",
+    "recursive/**",
+    "set/lib[0-9a-f]",
+    "wildcard/*",
+]
+exclude = [
+    # this exclude filter should be ignored, since we add `folder`
+    # and `folder/*` to the members, which overrides any exclude filters.
+    "folder/lib1",
+    "question/lib2",
+    "recursive/exclude1",
+    "recursive/include1/exclude2",
+    "set/libe",
+    "wildcard/exclude",
+]
+
+[features]
+dependencies = [
+    "folder_lib1",
+    "folder_lib2",
+    "question_lib1",
+    "recursive_include1",
+    "recursive_include2",
+    "set_lib1",
+    "set_libf",
+    "wildcard_include",
+]
+
+[[bin]]
+name = "dependencies"
+path = "bin/dependencies.rs"
+required-features = ["dependencies"]

--- a/workspace/bin/dependencies.rs
+++ b/workspace/bin/dependencies.rs
@@ -1,0 +1,16 @@
+pub use external_lib;
+pub use member;
+pub use folder_lib1;
+pub use folder_lib2;
+pub use question_lib1;
+pub use recursive_include1;
+pub use recursive_include2;
+pub use set_lib1;
+pub use set_libf;
+pub use wildcard_include;
+
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn main() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/folder/Cargo.toml
+++ b/workspace/folder/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "folder"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "lib.rs"

--- a/workspace/folder/lib.rs
+++ b/workspace/folder/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/folder/lib1/Cargo.toml
+++ b/workspace/folder/lib1/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "folder_lib1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/folder/lib1/src/lib.rs
+++ b/workspace/folder/lib1/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/folder/lib2/Cargo.toml
+++ b/workspace/folder/lib2/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "folder_lib2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/folder/lib2/src/lib.rs
+++ b/workspace/folder/lib2/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/other/Cargo.toml
+++ b/workspace/other/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "other"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/other/src/lib.rs
+++ b/workspace/other/src/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/question/lib/Cargo.toml
+++ b/workspace/question/lib/Cargo.toml
@@ -1,0 +1,9 @@
+# NOTE: should be ignored
+[package]
+name = "question_lib"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/question/lib/src/lib.rs
+++ b/workspace/question/lib/src/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/question/lib1/Cargo.toml
+++ b/workspace/question/lib1/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "question_lib1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/question/lib1/src/lib.rs
+++ b/workspace/question/lib1/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/question/lib12/Cargo.toml
+++ b/workspace/question/lib12/Cargo.toml
@@ -1,0 +1,9 @@
+# NOTE: should be ignored
+[package]
+name = "question_lib12"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/question/lib12/src/lib.rs
+++ b/workspace/question/lib12/src/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/question/lib2/Cargo.toml
+++ b/workspace/question/lib2/Cargo.toml
@@ -1,0 +1,9 @@
+# NOTE: should be ignored
+[package]
+name = "question_lib2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/question/lib2/src/lib.rs
+++ b/workspace/question/lib2/src/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/recursive/exclude1/Cargo.toml
+++ b/workspace/recursive/exclude1/Cargo.toml
@@ -1,0 +1,12 @@
+# NOTE: should be ignored
+[package]
+name = "recursive_exclude1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]

--- a/workspace/recursive/exclude1/lib.rs
+++ b/workspace/recursive/exclude1/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/recursive/include1/Cargo.toml
+++ b/workspace/recursive/include1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "recursive_include1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]

--- a/workspace/recursive/include1/exclude2/Cargo.toml
+++ b/workspace/recursive/include1/exclude2/Cargo.toml
@@ -1,0 +1,12 @@
+# NOTE: should be ignored
+[package]
+name = "recursive_exclude2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]

--- a/workspace/recursive/include1/exclude2/lib.rs
+++ b/workspace/recursive/include1/exclude2/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/recursive/include1/include2/Cargo.toml
+++ b/workspace/recursive/include1/include2/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "recursive_include2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]

--- a/workspace/recursive/include1/include2/lib.rs
+++ b/workspace/recursive/include1/include2/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/recursive/include1/lib.rs
+++ b/workspace/recursive/include1/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/set/lib1/Cargo.toml
+++ b/workspace/set/lib1/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "set_lib1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/set/lib1/src/lib.rs
+++ b/workspace/set/lib1/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/set/libe/Cargo.toml
+++ b/workspace/set/libe/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "set_libe"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/set/libe/src/lib.rs
+++ b/workspace/set/libe/src/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/set/libf/Cargo.toml
+++ b/workspace/set/libf/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "set_libf"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/set/libf/src/lib.rs
+++ b/workspace/set/libf/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/set/libg/Cargo.toml
+++ b/workspace/set/libg/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "set_libg"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/set/libg/src/lib.rs
+++ b/workspace/set/libg/src/lib.rs
@@ -1,0 +1,6 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+compile_error!("crate should not compile");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/wildcard/exclude/Cargo.toml
+++ b/workspace/wildcard/exclude/Cargo.toml
@@ -1,0 +1,9 @@
+# NOTE: should be ignored
+[package]
+name = "wildcard_exclude"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/wildcard/exclude/src/lib.rs
+++ b/workspace/wildcard/exclude/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}

--- a/workspace/wildcard/include/Cargo.toml
+++ b/workspace/wildcard/include/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wildcard_include"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/workspace/wildcard/include/src/lib.rs
+++ b/workspace/wildcard/include/src/lib.rs
@@ -1,0 +1,5 @@
+pub static CRATE: &str = env!("CARGO_PKG_NAME");
+
+pub fn print() {
+    println!("Hello from {}, {}", CRATE, file!());
+}


### PR DESCRIPTION
Added the following types of workspace members:
- Include wildcard globs.
- Include set globs.
- Include question globs.
- Include recursive wildcard globs.
- Exclude filters for all above.
- Override exclude filters by providing a non-global directory include.

Basically, this will test if our workspace support actually meets the Cargo workspaces specifications.